### PR TITLE
fix: scope metric variables to collector function

### DIFF
--- a/internal/collector/icmp_collector.go
+++ b/internal/collector/icmp_collector.go
@@ -116,15 +116,6 @@ func PingHandler(registry *prometheus.Registry, pingSuccessGauge prometheus.Gaug
 		p := parseParams(r)
 		start := time.Now()
 
-		// TODO use atomic lock and reduce lock duration, dont think this is needed
-		mutex.Lock()
-
-		// assume failure
-		pingSuccessGauge.Set(0)
-		pingTimeoutGauge.Set(1)
-
-		mutex.Unlock()
-
 		log.Debugf("Request received with parameters: target=%v, count=%v, size=%v, interval=%v, timeout=%v, ttl=%v, packet=%v",
 			p.target, p.count, p.size, p.interval, p.timeout, p.ttl, p.packet)
 
@@ -152,7 +143,6 @@ func PingHandler(registry *prometheus.Registry, pingSuccessGauge prometheus.Gaug
 			log.Debugf("OnFinish: target=%v, PacketsSent=%d, PacketsRecv=%d, PacketLoss=%f%%, MinRtt=%v, AvgRtt=%v, MaxRtt=%v, StdDevRtt=%v, Duration=%v",
 				stats.IPAddr, pinger.PacketsSent, pinger.PacketsRecv, stats.PacketLoss, stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt, time.Since(start))
 
-			// lock while we attribute values to
 			mutex.Lock()
 			if pinger.PacketsRecv > 0 && pinger.Timeout > time.Since(start) {
 				log.Debugf("Ping successful: target=%v", stats.IPAddr)

--- a/internal/collector/icmp_collector.go
+++ b/internal/collector/icmp_collector.go
@@ -114,41 +114,49 @@ func PingHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		const (
-			namespace = "ping_"
+			namespace = "ping"
 		)
 
 		var (
 			pingSuccessGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "success",
-				Help: "Returns whether the ping succeeded",
+				Namespace: namespace,
+				Name:      "success",
+				Help:      "Returns whether the ping succeeded",
 			})
 			pingTimeoutGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "timeout",
-				Help: "Returns whether the ping failed by timeout",
+				Namespace: namespace,
+				Name:      "timeout",
+				Help:      "Returns whether the ping failed by timeout",
 			})
 			probeDurationGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "duration_seconds",
-				Help: "Returns how long the probe took to complete in seconds",
+				Namespace: namespace,
+				Name:      "duration_seconds",
+				Help:      "Returns how long the probe took to complete in seconds",
 			})
 			minGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "rtt_min_seconds",
-				Help: "Best round trip time",
+				Namespace: namespace,
+				Name:      "rtt_min_seconds",
+				Help:      "Best round trip time",
 			})
 			maxGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "rtt_max_seconds",
-				Help: "Worst round trip time",
+				Namespace: namespace,
+				Name:      "rtt_max_seconds",
+				Help:      "Worst round trip time",
 			})
 			avgGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "rtt_avg_seconds",
-				Help: "Mean round trip time",
+				Namespace: namespace,
+				Name:      "rtt_avg_seconds",
+				Help:      "Mean round trip time",
 			})
 			stddevGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "rtt_std_deviation",
-				Help: "Standard deviation",
+				Namespace: namespace,
+				Name:      "rtt_std_deviation",
+				Help:      "Standard deviation",
 			})
 			lossGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: namespace + "loss_ratio",
-				Help: "Packet loss from 0 to 100",
+				Namespace: namespace,
+				Name:      "loss_ratio",
+				Help:      "Packet loss from 0 to 100",
 			})
 		)
 

--- a/internal/collector/icmp_collector.go
+++ b/internal/collector/icmp_collector.go
@@ -159,11 +159,11 @@ func PingHandler(registry *prometheus.Registry, pingSuccessGauge prometheus.Gaug
 				pingSuccessGauge.Set(1)
 				pingTimeoutGauge.Set(0)
 			} else if pinger.Timeout < time.Since(start) {
-				log.Debugf("Ping timeout: target=%v", stats.IPAddr)
+				log.Infof("Ping timeout: target=%v, timeout=%v, duration=%v", stats.IPAddr, pinger.Timeout, time.Since(start))
 				pingTimeoutGauge.Set(1)
 				pingSuccessGauge.Set(0)
 			} else if pinger.PacketsRecv == 0 {
-				log.Debugf("Ping failed, no packets received: target=%v", stats.IPAddr)
+				log.Infof("Ping failed, no packets received: target=%v, packetsRecv=%v, packetsSent=%v", stats.IPAddr, pinger.PacketsRecv, pinger.PacketsSent)
 				pingSuccessGauge.Set(0)
 				pingTimeoutGauge.Set(0)
 			}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PingMetrics struct {
+	PingSuccessGauge   prometheus.Gauge
+	PingTimeoutGauge   prometheus.Gauge
+	ProbeDurationGauge prometheus.Gauge
+	MinGauge           prometheus.Gauge
+	MaxGauge           prometheus.Gauge
+	AvgGauge           prometheus.Gauge
+	StddevGauge        prometheus.Gauge
+	LossGauge          prometheus.Gauge
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
-	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/wbollock/ping_exporter/internal/collector"
-	"github.com/wbollock/ping_exporter/internal/metrics"
 )
 
 func SetupServer() http.Handler {
@@ -26,63 +23,13 @@ func SetupServer() http.Handler {
 		defaultMetricsPath = "/metrics"
 	)
 
-	const namespace = "ping_"
-
-	var (
-		pingSuccessGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "success",
-			Help: "Returns whether the ping succeeded",
-		})
-		pingTimeoutGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "timeout",
-			Help: "Returns whether the ping failed by timeout",
-		})
-		probeDurationGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "duration_seconds",
-			Help: "Returns how long the probe took to complete in seconds",
-		})
-		minGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "rtt_min_seconds",
-			Help: "Best round trip time",
-		})
-		maxGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "rtt_max_seconds",
-			Help: "Worst round trip time",
-		})
-		avgGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "rtt_avg_seconds",
-			Help: "Mean round trip time",
-		})
-		stddevGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "rtt_std_deviation",
-			Help: "Standard deviation",
-		})
-		lossGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: namespace + "loss_ratio",
-			Help: "Packet loss from 0 to 100",
-		})
-	)
-
 	mux := http.NewServeMux()
 
 	mux.Handle(defaultMetricsPath, promhttp.Handler())
 
-	var mutex sync.Mutex
-	registry := prometheus.NewRegistry()
+	pingHandler := collector.PingHandler()
 
-	metrics := metrics.PingMetrics{
-		PingSuccessGauge:   pingSuccessGauge,
-		PingTimeoutGauge:   pingTimeoutGauge,
-		ProbeDurationGauge: probeDurationGauge,
-		MinGauge:           minGauge,
-		MaxGauge:           maxGauge,
-		AvgGauge:           avgGauge,
-		StddevGauge:        stddevGauge,
-		LossGauge:          lossGauge,
-	}
-
-	registry.MustRegister(metrics.PingSuccessGauge, metrics.PingTimeoutGauge, metrics.ProbeDurationGauge, metrics.MinGauge, metrics.MaxGauge, metrics.AvgGauge, metrics.StddevGauge, metrics.LossGauge)
-	mux.HandleFunc("/probe", collector.PingHandler(registry, metrics, &mutex))
+	mux.HandleFunc("/probe", pingHandler)
 
 	// for non-standard web servers, need to register handlers
 	mux.HandleFunc("/debug/pprof/", http.HandlerFunc(pprof.Index))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,55 +13,56 @@ import (
 	"github.com/wbollock/ping_exporter/internal/metrics"
 )
 
-const (
-	defaultHTML = `<html>
-			<head><title>Ping Exporter</title></head>
-			<body>
-			<h1>Ping Exporter</h1>
-			<p><a href='%s'>Metrics</a></p>
-			</body>
-			</html>`
-	defaultMetricsPath = "/metrics"
-)
-
-const namespace = "ping_"
-
-var (
-	pingSuccessGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "success",
-		Help: "Returns whether the ping succeeded",
-	})
-	pingTimeoutGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "timeout",
-		Help: "Returns whether the ping failed by timeout",
-	})
-	probeDurationGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "duration_seconds",
-		Help: "Returns how long the probe took to complete in seconds",
-	})
-	minGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "rtt_min_seconds",
-		Help: "Best round trip time",
-	})
-	maxGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "rtt_max_seconds",
-		Help: "Worst round trip time",
-	})
-	avgGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "rtt_avg_seconds",
-		Help: "Mean round trip time",
-	})
-	stddevGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "rtt_std_deviation",
-		Help: "Standard deviation",
-	})
-	lossGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: namespace + "loss_ratio",
-		Help: "Packet loss from 0 to 100",
-	})
-)
-
 func SetupServer() http.Handler {
+
+	const (
+		defaultHTML = `<html>
+				<head><title>Ping Exporter</title></head>
+				<body>
+				<h1>Ping Exporter</h1>
+				<p><a href='%s'>Metrics</a></p>
+				</body>
+				</html>`
+		defaultMetricsPath = "/metrics"
+	)
+
+	const namespace = "ping_"
+
+	var (
+		pingSuccessGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "success",
+			Help: "Returns whether the ping succeeded",
+		})
+		pingTimeoutGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "timeout",
+			Help: "Returns whether the ping failed by timeout",
+		})
+		probeDurationGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "duration_seconds",
+			Help: "Returns how long the probe took to complete in seconds",
+		})
+		minGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "rtt_min_seconds",
+			Help: "Best round trip time",
+		})
+		maxGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "rtt_max_seconds",
+			Help: "Worst round trip time",
+		})
+		avgGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "rtt_avg_seconds",
+			Help: "Mean round trip time",
+		})
+		stddevGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "rtt_std_deviation",
+			Help: "Standard deviation",
+		})
+		lossGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: namespace + "loss_ratio",
+			Help: "Packet loss from 0 to 100",
+		})
+	)
+
 	mux := http.NewServeMux()
 
 	mux.Handle(defaultMetricsPath, promhttp.Handler())


### PR DESCRIPTION
This helps fix some concurrency problems by scoping and instantiating metric variables to each probe.

It also tightens up the ping_success logic to closely match `man ping` and provide Info logs on ping timeout or other failures

Lastly there is a refactor to reduce the long parameter list in the collector function